### PR TITLE
Add option for multiple custom menu modifiers

### DIFF
--- a/src/main/java/org/ipvp/canvas/paginate/AbstractPaginatedMenuBuilder.java
+++ b/src/main/java/org/ipvp/canvas/paginate/AbstractPaginatedMenuBuilder.java
@@ -30,6 +30,8 @@ import org.ipvp.canvas.slot.Slot;
 import org.ipvp.canvas.template.ItemStackTemplate;
 import org.ipvp.canvas.template.StaticItemTemplate;
 
+import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -40,7 +42,7 @@ import java.util.function.Consumer;
 public abstract class AbstractPaginatedMenuBuilder<T extends AbstractPaginatedMenuBuilder<T>> {
 
     private final Menu.Builder<?> pageBuilder;
-    private Consumer<Menu> newMenuModifier;
+    private final List<Consumer<Menu>> newMenuModifiers;
     private int previousButtonSlot = -1;
     private int nextButtonSlot = -1;
     private ItemStackTemplate previousButton;
@@ -50,6 +52,7 @@ public abstract class AbstractPaginatedMenuBuilder<T extends AbstractPaginatedMe
 
     public AbstractPaginatedMenuBuilder(Menu.Builder<?> pageBuilder) {
         this.pageBuilder = pageBuilder;
+        this.newMenuModifiers = new LinkedList<>();
     }
 
     /**
@@ -62,23 +65,34 @@ public abstract class AbstractPaginatedMenuBuilder<T extends AbstractPaginatedMe
     }
 
     /**
-     * Sets the modifier for when a new menu is created.
+     * Adds a modifier for when a new menu is created.
      *
      * @param newMenuModifier modifier
      * @return fluent pattern
      */
     public T newMenuModifier(Consumer<Menu> newMenuModifier) {
-        this.newMenuModifier = newMenuModifier;
+        if (newMenuModifier != null)
+            this.newMenuModifiers.add(newMenuModifier);
         return (T) this;
     }
 
     /**
-     * Gets the current modifier for when a new menu is created.
+     * Adds multiple modifiers for when a new menu is created.
+     * @param newMenuModifiers a collection of modifiers
+     * @return fluent pattern
+     */
+    public T newMenuModifiers(Collection<Consumer<Menu>> newMenuModifiers) {
+        newMenuModifiers.forEach(this::newMenuModifier);
+        return (T) this;
+    }
+
+    /**
+     * Gets the current modifiers for when a new menu is created.
      *
      * @return menu modifier
      */
-    public Consumer<Menu> getNewMenuModifier() {
-        return newMenuModifier;
+    public List<Consumer<Menu>> getNewMenuModifiers() {
+        return newMenuModifiers;
     }
 
     /**

--- a/src/main/java/org/ipvp/canvas/paginate/AbstractPaginatedMenuBuilder.java
+++ b/src/main/java/org/ipvp/canvas/paginate/AbstractPaginatedMenuBuilder.java
@@ -71,8 +71,10 @@ public abstract class AbstractPaginatedMenuBuilder<T extends AbstractPaginatedMe
      * @return fluent pattern
      */
     public T newMenuModifier(Consumer<Menu> newMenuModifier) {
-        if (newMenuModifier != null)
-            this.newMenuModifiers.add(newMenuModifier);
+        if (newMenuModifier == null) {
+            throw new IllegalArgumentException("Menu modifier cannot be null");
+        }
+        this.newMenuModifiers.add(newMenuModifier);
         return (T) this;
     }
 

--- a/src/main/java/org/ipvp/canvas/paginate/MultiSectionPaginatedMenuBuilder.java
+++ b/src/main/java/org/ipvp/canvas/paginate/MultiSectionPaginatedMenuBuilder.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 /**
  * Fluent builder to assist with creating series of Menus.
@@ -142,8 +143,9 @@ public class MultiSectionPaginatedMenuBuilder extends AbstractPaginatedMenuBuild
 
         do {
             Menu page = getPageBuilder().build();
-            if (getNewMenuModifier() != null) {
-                getNewMenuModifier().accept(page);
+            if (!getNewMenuModifiers().isEmpty()) {
+                for (Consumer<Menu> menuModifier : getNewMenuModifiers())
+                    menuModifier.accept(page);
             }
             setPaginationIcon(page, getPreviousButtonSlot(), getPreviousButtonEmpty());
             setPaginationIcon(page, getNextButtonSlot(), getNextButtonEmpty());

--- a/src/main/java/org/ipvp/canvas/paginate/MultiSectionPaginatedMenuBuilder.java
+++ b/src/main/java/org/ipvp/canvas/paginate/MultiSectionPaginatedMenuBuilder.java
@@ -144,8 +144,9 @@ public class MultiSectionPaginatedMenuBuilder extends AbstractPaginatedMenuBuild
         do {
             Menu page = getPageBuilder().build();
             if (!getNewMenuModifiers().isEmpty()) {
-                for (Consumer<Menu> menuModifier : getNewMenuModifiers())
+                for (Consumer<Menu> menuModifier : getNewMenuModifiers()) {
                     menuModifier.accept(page);
+                }
             }
             setPaginationIcon(page, getPreviousButtonSlot(), getPreviousButtonEmpty());
             setPaginationIcon(page, getNextButtonSlot(), getNextButtonEmpty());

--- a/src/main/java/org/ipvp/canvas/paginate/PaginatedMenuBuilder.java
+++ b/src/main/java/org/ipvp/canvas/paginate/PaginatedMenuBuilder.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * Fluent builder to assist with creating series of Menus.
@@ -134,8 +135,9 @@ public class PaginatedMenuBuilder extends AbstractPaginatedMenuBuilder<Paginated
 
         do {
             Menu page = getPageBuilder().build();
-            if (getNewMenuModifier() != null) {
-                getNewMenuModifier().accept(page);
+            if (!getNewMenuModifiers().isEmpty()) {
+                for (Consumer<Menu> menuModifier : getNewMenuModifiers())
+                    menuModifier.accept(page);
             }
             List<Integer> validSlots = getValidSlots(page);
             setPaginationIcon(page, getPreviousButtonSlot(), getPreviousButtonEmpty());

--- a/src/main/java/org/ipvp/canvas/paginate/PaginatedMenuBuilder.java
+++ b/src/main/java/org/ipvp/canvas/paginate/PaginatedMenuBuilder.java
@@ -136,8 +136,9 @@ public class PaginatedMenuBuilder extends AbstractPaginatedMenuBuilder<Paginated
         do {
             Menu page = getPageBuilder().build();
             if (!getNewMenuModifiers().isEmpty()) {
-                for (Consumer<Menu> menuModifier : getNewMenuModifiers())
+                for (Consumer<Menu> menuModifier : getNewMenuModifiers()) {
                     menuModifier.accept(page);
+                }
             }
             List<Integer> validSlots = getValidSlots(page);
             setPaginationIcon(page, getPreviousButtonSlot(), getPreviousButtonEmpty());


### PR DESCRIPTION
I feel that allowing for more than one custom menu modifier would be a meaningful addition to the AbstractPaginatedMenuBuilder class.

- Changed attribute newMenuModifier into a List initialized in the constructor
- Added null check in method newMenuModifier()
- Added method newMenuModifiers() to add multiple menu consumers at once
- Rather than just applying a single menu modifier, the Builder classes now iterate through the modifier list and apply all of them in order